### PR TITLE
added raw link to header

### DIFF
--- a/squeezebox/drivers/squeezebox-player.groovy
+++ b/squeezebox/drivers/squeezebox-player.groovy
@@ -1,6 +1,9 @@
 /**
  *  Squeezebox Player
  *
+ *  Git Hub Raw Link - Use for Import into Hubitat
+ *  https://raw.githubusercontent.com/xap-code/hubitat/master/squeezebox/drivers/squeezebox-player.groovy
+ *
  *  Copyright 2017 Ben Deitch
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except


### PR DESCRIPTION
The raw link can be copied and pasted into the import function of hubitat.  Removes the need to have to go back to GitHub to get the latest code.