### PR TITLE
adding Raw Link for hubitat import

### DIFF
--- a/squeezebox/app/squeezebox-connect.groovy
+++ b/squeezebox/app/squeezebox-connect.groovy
@@ -1,6 +1,9 @@
 /**
  *  Squeezebox Connect
  *
+ *  Git Hub Raw Link - Use for Import into Hubitat
+ *  https://raw.githubusercontent.com/xap-code/hubitat/master/squeezebox/app/squeezebox-connect.groovy
+ *
  *  Copyright 2017 Ben Deitch
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except


### PR DESCRIPTION
Raw link allows users to import new code without having to go back to Github.